### PR TITLE
Add API token support in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Example config.json:
           "vin": "5JJYCB522AB296261",
           "username": "bobs@burgers.com",
           "password": "bobbobbaran",
+          "autoToken": "authToken"
           "waitMinutes": 1
         }
       ]
@@ -34,6 +35,12 @@ a unique name for this lock, like "Charge Port" in the example above.
 
 _If_ you define a value for `waitMinutes`, you can control the amount of
 time the plugin will wait for the car to wake up. The default is one minute.
+
+_If_ you define a value for `authToken`,
+you do not need to provide your username or password credentials.
+Generating a token can be done many ways.
+[Tokens for Teslas](https://tokens-for-teslas.herokuapp.com) is one option.
+`npm install -g generate-tesla-token` is another.
 
 If you use the example above, you would gain Siri commands like:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,12 +25,12 @@ class TeslaAccessory {
   frunk: string | null;
   chargePort: string | null;
   vin: string;
-  username: string;
-  password: string;
+  username: string | null;
+  password: string | null;
   waitMinutes: number;
+  authToken: string | null;
 
   // Runtime state.
-  authToken: string | undefined;
   vehicleID: string | undefined;
 
   // Services exposed.
@@ -50,6 +50,7 @@ class TeslaAccessory {
     this.username = config["username"];
     this.password = config["password"];
     this.waitMinutes = config["waitMinutes"] || 1; // default to one minute.
+    this.authToken = config["authToken"];
 
     const lockService = new Service.LockMechanism(this.name, "vehicle");
 


### PR DESCRIPTION
    This commit adds support for a user to specify an authToken in their
    config instead of providing a username and password; since leaving
    a password in plain text is typically undesirable.

    Be warned that using the authToken or providing a username and password,
    in this scenario, is almost identical as far as security is concerned.
    Anyone with this token will have full control of the vehicle.

    * Resolves #7 Add API token support