### PR TITLE
Fix for garage door state being null value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -226,6 +226,15 @@ class TeslaAccessory {
 
   getCurrentGarageDoorState = async () => {
     this.log("HomeLink does not support garage door status.");
+    this.log("Always setting garage door state to closed.");
+
+    if (!this.homelinkService.Characteristic.TargetDoorState) {
+      this.homelinkService.setCharacteristic(
+        Characteristic.TargetDoorState,
+        Characteristic.TargetDoorState.CLOSED,
+      );
+    }
+
   };
 
   setTargetGarageDoorState = async () => {
@@ -248,10 +257,6 @@ class TeslaAccessory {
 
     } else this.log("HomeLink not available.");
     
-    this.log("HomeLink does not support garage door status.");
-    this.log("Always setting garage door state to closed.");
-    const doorState = 1;
-    return doorState;
   };
 
   //

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,7 +236,6 @@ class TeslaAccessory {
     }
     
     return;
-
   };
 
   setTargetGarageDoorState = async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,8 @@ class TeslaAccessory {
         Characteristic.TargetDoorState.CLOSED,
       );
     }
+    
+    return;
 
   };
 
@@ -254,9 +256,7 @@ class TeslaAccessory {
         this.longitude,
       );
       this.log("HomeLink activated: ", results.result);
-
     } else this.log("HomeLink not available.");
-    
   };
 
   //

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,6 @@ class TeslaAccessory {
 
   getCurrentGarageDoorState = async () => {
     this.log("HomeLink does not support garage door status.");
-    return;
   };
 
   setTargetGarageDoorState = async () => {
@@ -246,7 +245,13 @@ class TeslaAccessory {
         this.longitude,
       );
       this.log("HomeLink activated: ", results.result);
+
     } else this.log("HomeLink not available.");
+    
+    this.log("HomeLink does not support garage door status.");
+    this.log("Always setting garage door state to closed.");
+    const doorState = 1;
+    return doorState;
   };
 
   //


### PR DESCRIPTION
In testing Homebridge 1.3, it was generating an error message that the TargetDoorState characteristic had no value. Added code to always set value to CLOSED as Homelink does not support the door state.