### PR TITLE
added sentry mode get/set as lockmechanism

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -60,6 +60,10 @@
         "title": "Disable Door Lock Service",
         "type": "boolean"
       },
+      "disableSentryMode": {
+        "title": "Disable Sentry Mode Service",
+        "type": "boolean"
+      },
       "disableClimate": {
         "title": "Disable Climate Control Service",
         "type": "boolean"

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -56,6 +56,7 @@ export interface VehicleState {
   remote_start: boolean;
   remote_start_supported: boolean;
   rt: number;
+  sentry_mode: boolean;
   software_update: {
     expected_duration_sec: number;
     status: string;


### PR DESCRIPTION
followed convention followed by locks to use create sentry mode functionality. there's an async copy of the setter i didn't use here (setSentryModeAsync). there was also a status bool for sentry available but i figure all cars should have it, it can be disabled in config if it for some reason isn't working for someone