### PR TITLE
Sentry Mode Switch Option

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -64,6 +64,11 @@
         "title": "Disable Sentry Mode Service",
         "type": "boolean"
       },
+      "sentryModeSwitch": {
+        "title": "Sentry Mode Service as a Switch",
+        "type": "boolean",
+        "description": "This will configure Sentry Mode as a switch, instead of a lock."
+      },
       "disableClimate": {
         "title": "Disable Climate Control Service",
         "type": "boolean"


### PR DESCRIPTION
Added a configuration option to load Sentry Mode as a switch, instead of a lock. The default is still a lock.