### PR TITLE
Add Defrost Service option

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -70,7 +70,7 @@
       "disableDefrost": {
         "title": "Disable Defrost Control Service",
         "type": "boolean",
-        "description": "If climate control service is disable, this switch will also be disabled."
+        "description": "If climate control service is disabled, this switch will also be disabled."
       },
       "disableTrunk": {
         "title": "Disable Trunk Service",

--- a/config.schema.json
+++ b/config.schema.json
@@ -67,6 +67,10 @@
         "title": "Disable Climate Control Service",
         "type": "boolean"
       },
+      "disableDefrost": {
+        "title": "Disable Defrost Control Service",
+        "type": "boolean"
+      },
       "disableTrunk": {
         "title": "Disable Trunk Service",
         "type": "boolean"

--- a/config.schema.json
+++ b/config.schema.json
@@ -69,7 +69,8 @@
       },
       "disableDefrost": {
         "title": "Disable Defrost Control Service",
-        "type": "boolean"
+        "type": "boolean",
+        "description": "If climate control service is disable, this switch will also be disabled."
       },
       "disableTrunk": {
         "title": "Disable Trunk Service",

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,8 @@ class TeslaAccessory {
       .on("get", callbackify(this.getDefrostOn))
       .on("set", callbackify(this.setDefrostOn));
 
+    this.defrostService = defrostService;
+
     // Enable the rear trunk lock service.
     const trunkService = new Service.LockMechanism(
       baseName + " Trunk",

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ class TeslaAccessory {
   disableFrunk: boolean | null;
   disableChargePort: boolean | null;
   disableClimate: boolean | null;
+  disableDefrost: boolean | null;
   disableCharger: boolean | null;
   disableStarter: boolean | null;
   enableHomeLink: boolean | null;
@@ -53,6 +54,7 @@ class TeslaAccessory {
   frunkService: any;
   chargePortService: any;
   climateService: any;
+  defrostService: any;
   chargerService: any;
   starterService: any;
   homelinkService: any;
@@ -75,6 +77,7 @@ class TeslaAccessory {
     this.disableFrunk = config["disableFrunk"] || false;
     this.disableChargePort = config["disableChargePort"] || false;
     this.disableClimate = config["disableClimate"] || false;
+    this.disableDefrost = config["disableDefrost"] || false;
     this.disableCharger = config["disableCharger"] || false;
     this.disableStarter = config["disableStarter"] || false;
     this.enableHomeLink = config["enableHomeLink"] || false;
@@ -141,6 +144,13 @@ class TeslaAccessory {
       .on("set", callbackify(this.setClimateOn));
 
     this.climateService = climateService;
+
+    const defrostService = new Service.Switch(baseName + " Defrost", "defrost");
+
+    defrostService
+      .getCharacteristic(Characteristic.On)
+      .on("get", callbackify(this.getDefrostOn))
+      .on("set", callbackify(this.setDefrostOn));
 
     // Enable the rear trunk lock service.
     const trunkService = new Service.LockMechanism(
@@ -245,6 +255,7 @@ class TeslaAccessory {
       ...(this.disableDoors ? [] : [this.lockService]),
       ...(this.disableSentryMode ? [] : [this.sentryModeService]),
       ...(this.disableClimate ? [] : [this.climateService]),
+      ...(this.disableDefrost ? [] : [this.defrostService]),
       ...(this.disableTrunk ? [] : [this.trunkService]),
       ...(this.disableFrunk ? [] : [this.frunkService]),
       ...(this.disableCharger ? [] : [this.chargerService]),
@@ -542,6 +553,39 @@ class TeslaAccessory {
     } else {
       await api("climateStop", options);
     }
+  };
+
+  //
+  // Defrost Switch
+  //
+
+  getDefrostOn = async () => {
+    const options = await this.getOptions();
+
+    if (options.isAsleep) {
+      this.logIgnored("defrost state");
+      throw new Error("Vehicle is asleep.");
+    }
+
+    // This will only succeed if the car is already online. We don't want to
+    // wake it up just to see if climate is on because that could drain battery!
+    const state: ClimateState = await api("climateState", options);
+
+    const on = state.defrost_mode;
+
+    this.log("Defrost on?", !!on);
+    return !!on;
+  };
+
+  setDefrostOn = async (on) => {
+    const options = await this.getOptions();
+
+    // Wake up, this is important!
+    await this.wakeUp(options);
+
+    this.log("Set defrost to", on);
+
+    await api("maxDefrost", options, on);
   };
 
   //

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,8 @@ class TeslaAccessory {
     this.disableFrunk = config["disableFrunk"] || false;
     this.disableChargePort = config["disableChargePort"] || false;
     this.disableClimate = config["disableClimate"] || false;
-    this.disableDefrost = config["disableDefrost"] || false;
+    this.disableDefrost =
+      (this.disableClimate && config["disableDefrost"]) || false;
     this.disableCharger = config["disableCharger"] || false;
     this.disableStarter = config["disableStarter"] || false;
     this.enableHomeLink = config["enableHomeLink"] || false;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -118,6 +118,7 @@ const ExampleVehicleStateResponse = {
 export interface ClimateState {
   battery_heater: boolean;
   battery_heater_no_power: any;
+  defrost_mode: number;
   driver_temp_setting: number;
   fan_status: number;
   inside_temp: number;
@@ -149,6 +150,7 @@ export interface ClimateState {
 const ExampleClimateStateResponse: ClimateState = {
   battery_heater: false,
   battery_heater_no_power: null,
+  defrost_mode: 0,
   driver_temp_setting: 22.2,
   fan_status: 0,
   inside_temp: 12.9,


### PR DESCRIPTION
Hi! 

Thanks for this plugin! I use it everyday :) Since I live in the northern climate and the winter season is coming up I found myself always having to open the app to toggle the defrost option so I thought that would be a nice little toggle to expose by default. So I can just tell Siri to defrost my car. Of course people living in the south can disable it if they need. Wasn't sure if that toggle should be opt-in or opt-out by default.

Little note that when disabling defrost mode it does leave the climate on which we can toggle off with the climate service switch (not sure if we should also disable the climate if we toggle defrost off)... The relation between the 2 services are made clear. So I made sure to disable the defrost mode if the climate service is off as well. 

Any feedback welcome!