### PR TITLE
fixed logic for disableDefrost, should have been or'ed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-tesla",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Tesla support for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ class TeslaAccessory {
     this.disableChargePort = config["disableChargePort"] || false;
     this.disableClimate = config["disableClimate"] || false;
     this.disableDefrost =
-      (this.disableClimate && config["disableDefrost"]) || false;
+      (this.disableClimate || config["disableDefrost"]) || false;
     this.disableCharger = config["disableCharger"] || false;
     this.disableStarter = config["disableStarter"] || false;
     this.enableHomeLink = config["enableHomeLink"] || false;


### PR DESCRIPTION
The logic for disableDefrost was ` (this.disableClimate && config["disableDefrost"])` which I believe was an accident since we kind of double negative with the var names, 'disable...'. We want defrost to be disabled if the climate OR defrost is set to disabled. We shouldn't require both.