### PR TITLE
Charging amps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ After [installation](#installation) below, you'll get the default services enabl
 You can also configure the plugin to enable these additional services:
 
 - _"Set the charge limit to 80%"_
+- _"Set the charge amps to 24"_
 - _"Turn on the steering wheel heater"_
 - _"Turn on the defrost"_
 - _"Open the charge port"_

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ After [installation](#installation) below, you'll get the default services enabl
 You can also configure the plugin to enable these additional services:
 
 - _"Set the charge limit to 80%"_
-- _"Set the charge amps to 24"_
+- _"Set the charging amps to 24"_
 - _"Turn on the steering wheel heater"_
 - _"Turn on the defrost"_
 - _"Open the charge port"_

--- a/config.schema.json
+++ b/config.schema.json
@@ -111,11 +111,9 @@
       },
       "chargingAmps": {
         "title": "Charging Amps",
-        "type": "integer",
-        "default": 12,
-        "maximum": 48,
-        "minimum": 6,
-        "description": "Example: 'Set the charging amps to 24'"
+        "type": "boolean",
+        "default": false,
+        "description": "Example: 'Set the Charging amps to 24'. NOTE: Will appear in HomeKit as a Light bulb! There's no other way to do it."
       },
       "starter": {
         "title": "Starter",

--- a/config.schema.json
+++ b/config.schema.json
@@ -109,6 +109,14 @@
         "default": false,
         "description": "Example: 'Turn on the Charger' to begin charging the car"
       },
+      "chargingAmps": {
+        "title": "Charging Amps",
+        "type": "integer",
+        "default": 12,
+        "maximum": 48,
+        "minimum": 6,
+        "description": "Example: 'Set the charging amps to 24'"
+      },
       "starter": {
         "title": "Starter",
         "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-teslala",
-  "version": "4.1.0",
-  "description": "Tesla support for Homebridge: https://github.com/rlisle/homebridge",
+  "version": "1.0.0",
+  "description": "Tesla support for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [
     "homebridge-plugin"

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "homebridge-tesla",
+  "name": "homebridge-teslala",
   "version": "4.1.0",
-  "description": "Tesla support for Homebridge: https://github.com/nfarina/homebridge",
+  "description": "Tesla support for Homebridge: https://github.com/rlisle/homebridge",
   "license": "ISC",
   "keywords": [
     "homebridge-plugin"
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/nfarina/homebridge-tesla.git"
+    "url": "git://github.com/rlisle/homebridge-tesla.git"
   },
   "bugs": {
-    "url": "http://github.com/nfarina/homebridge-tesla/issues"
+    "url": "http://github.com/rlisle/homebridge-tesla/issues"
   },
   "engines": {
     "node": ">=0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "homebridge-teslala",
-  "version": "1.0.0",
+  "name": "homebridge-tesla",
+  "version": "4.1.0",
   "description": "Tesla support for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [
@@ -8,10 +8,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/rlisle/homebridge-tesla.git"
+    "url": "git://github.com/nfarina/homebridge-tesla.git"
   },
   "bugs": {
-    "url": "http://github.com/rlisle/homebridge-tesla/issues"
+    "url": "http://github.com/nfarina/homebridge-tesla/issues"
   },
   "engines": {
     "node": ">=0.12.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 require("@babel/polyfill");
+import { ChargingAmpsService } from ".services/ChargingAmpsService";
 import { AccessoryConfig, API, HAP, Logging } from "homebridge";
 import { BatteryService } from "./services/BatteryService";
 import { ChargeLimitService } from "./services/ChargeLimitService";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { StarterService } from "./services/StarterService";
 import { SteeringWheelHeaterService } from "./services/SteeringWheelHeaterService";
 import {
   TeslaPluginService,
-  TeslaPluginServiceContext,
+  TeslaPluginServiceContext
 } from "./services/TeslaPluginService";
 import { FrontTrunk, RearTrunk, TrunkService } from "./services/TrunkService";
 import { VehicleLockService } from "./services/VehicleLockService";
@@ -85,6 +85,10 @@ class TeslaAccessory {
 
     if (getConfigValue(config, "charger")) {
       this.services.push(new ChargerService(context));
+    }
+
+    if (getConfigValue(config, "chargingAmps")) {
+      this.services.push(new ChargingAmpsService(context));
     }
 
     if (getConfigValue(config, "defrost")) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 require("@babel/polyfill");
-import { ChargingAmpsService } from ".services/ChargingAmpsService";
 import { AccessoryConfig, API, HAP, Logging } from "homebridge";
 import { BatteryService } from "./services/BatteryService";
 import { ChargeLimitService } from "./services/ChargeLimitService";
 import { ChargePortService } from "./services/ChargePortServices";
 import { ChargerService } from "./services/ChargerService";
+import { ChargingAmpsService } from "./services/ChargingAmpsService";
 import { ClimateService } from "./services/ClimateService";
 import { ClimateSwitchService } from "./services/ClimateSwitchService";
 import { ConnectionService } from "./services/ConnectionService";

--- a/src/services/ChargingAmpsService.ts
+++ b/src/services/ChargingAmpsService.ts
@@ -1,0 +1,74 @@
+import { Service } from "homebridge";
+import { VehicleData } from "../util/types";
+import {
+  TeslaPluginService,
+  TeslaPluginServiceContext
+} from "./TeslaPluginService";
+
+export class ChargingAmpsService extends TeslaPluginService {
+  service: Service;
+
+  // We need to set charging amps on a delay because the UX in the Home app is
+  // a lightbulb brightness slider that is "realtime" - so we will be told
+  // to change the charge level even as the user is dragging the slider around.
+  // We don't want to issue a million API commands so we'll wait a bit before
+  // actually sending the command.
+  setAmpsTimeoutId: NodeJS.Timeout | null = null;
+
+  constructor(context: TeslaPluginServiceContext) {
+    super(context);
+    const { hap, tesla } = context;
+
+    const service = new hap.Service.Lightbulb(
+      this.serviceName("Charging Amps"),
+      "chargingAmps",
+    );
+
+    const on = service
+      .getCharacteristic(hap.Characteristic.On)
+      .on("get", this.createGetter(this.getOn));
+
+    const brightness = service
+      .addCharacteristic(hap.Characteristic.Brightness)
+      .on("get", this.createGetter(this.getLevel))
+      .on("set", this.createSetter(this.setLevel));
+
+    this.service = service;
+
+    tesla.on("vehicleDataUpdated", (data) => {
+      on.updateValue(this.getOn(data));
+      brightness.updateValue(this.getLevel(data));
+    });
+  }
+
+  getOn(data: VehicleData | null) {
+    // Show off when not connected and no last-known state. Otherwise always
+    // "on".
+    return data ? true : false;
+  }
+
+  getLevel(data: VehicleData | null) {
+    // Show 0% when not connected and no last-known state.
+    return data ? data.charge_state.charge_current_request : 0;
+  }
+
+  async setLevel(value: number) {
+    if (this.setAmpsTimeoutId) {
+      clearTimeout(this.setAmpsTimeoutId);
+    }
+
+    // Set it in 2 seconds.
+    this.setAmpsTimeoutId = setTimeout(() => {
+      this.actuallySetLevel(value);
+    }, 2000);
+  }
+
+  async actuallySetLevel(value: number) {
+    const { log, tesla } = this.context;
+
+    await tesla.wakeAndCommand(async (options) => {
+      log(`Setting charging amps to ${value}…`);
+      await tesla.api("setChargingAmps", options, value);
+    });
+  }
+}


### PR DESCRIPTION
Add service for setting the Charging Amps setting. This is intended to be useful for RV users that are limited to a total of 30 or 50 amps for both their RV and for charging their Tesla. By monitoring the usage by the RV, the remainder can be allocated to charging the Tesla (with a suitable safety margin).